### PR TITLE
"Runtime function returned invalid data" error when returning payload.

### DIFF
--- a/docs/runtime-code-basics.md
+++ b/docs/runtime-code-basics.md
@@ -299,7 +299,7 @@ local function get_pokemon(_, payload)
       weight = result.weight,
       image = result.sprites.front_default
     }
-    return pokemon
+    return nk.json_encode(pokemon)
   end
 end
 


### PR DESCRIPTION
There was a runtime error when returning the payload from the pokemon.lua function get_pokemon, returning a json object to the client fixes this issue.