### PR TITLE
Notification codes must be greater than zero

### DIFF
--- a/docs/social-in-app-notifications.md
+++ b/docs/social-in-app-notifications.md
@@ -538,12 +538,13 @@ Authorization: Bearer <session token>
 
 ## Notification codes
 
-The server reserves all negative integer codes for messages sent implicitly on certain events. You can define your own notification codes by simply using values greater than or equal to 0.
+The server reserves all codes that are less than or equal to 0 for messages sent implicitly on certain events. You can define your own notification codes by simply using values greater than 0.
 
 The code is useful to decide how to display the notification in your UI.
 
 | Code | Purpose |
 | ---- | ------- |
+|&nbsp;0 | Reserved |
 |   -1 | User X wants to chat. |
 |   -2 | User X wants to add you as a friend. |
 |   -3 | User X accepted your friend invite. |


### PR DESCRIPTION
The docs say the notification codes can be greater than or equal to 0, but the actual implementation has a check for <= 0. Assuming the implementation is correct, the docs should be updated. I'm not sure if notification code 0 is actually used for anything by default, though.

runtime_lua_nakama.go
```lua
	code := l.CheckInt(4)
	if code <= 0 {
		l.ArgError(4, "expects code to number above 0")
		return 0
	}
```

runtime_go_nakama.go
```go
	if notification.Code <= 0 {
		return errors.New("expects code to number above 0")
	}
```