### PR TITLE
Lua convention is lower-case fields

### DIFF
--- a/docs/storage-access-controls.md
+++ b/docs/storage-access-controls.md
@@ -146,7 +146,7 @@ local object_ids = {
 }
 local objects = nk.storage_read(object_ids)
 for _, o in ipairs(objects) do
-  local message = ("value: %q"):format(o.Value)
+  local message = ("value: %q"):format(o.value)
   nk.logger_info(message)
 end
 ```


### PR DESCRIPTION
In the Lua example of "Object ownership" o.Value needs to be changed to o.value for it to work