### PR TITLE
Godot example code.

### DIFF
--- a/docs/advanced-streams.md
+++ b/docs/advanced-streams.md
@@ -104,6 +104,13 @@ SocketListener listener = new AbstractSocketListener() {
 };
 ```
 
+```gdscript tab="Godot"
+socket.connect("received_stream_state", self, "_on_stream_state")
+
+func _on_stream_state(p_state : NakamaRTAPI.StreamData):
+	print("Received data from stream: %s" % parse_json(p_state.state))
+```
+
 ## Receiving stream presence events
 
 When a new presence joins a stream or an existing presence leaves the server will broadcast presence events to all users currently on the stream.
@@ -211,6 +218,16 @@ SocketListener listener = new AbstractSocketListener() {
     }
   }
 };
+```
+
+```gdscript tab="Godot"
+socket.connect("received_stream_presence", self, "_on_stream_presence")
+
+func _on_stream_presence(p_presence : NakamaRTAPI.StreamPresenceEvent):
+	for p in p_presence.joins:
+		print("User ID: %s, Username: %s, Status: %s" % [p.user_id, p.username, p.status])
+	for p in p_presence.leaves:
+		print("User ID: %s, Username: %s, Status: %s" % [p.user_id, p.username, p.status])
 ```
 
 !!! Tip

--- a/docs/advanced-streams.md
+++ b/docs/advanced-streams.md
@@ -110,7 +110,8 @@ func _ready():
 	socket.connect("received_stream_state", self, "_on_stream_state")
 
 func _on_stream_state(p_state : NakamaRTAPI.StreamData):
-	print("Received data from stream: %s" % parse_json(p_state.state))
+	print("Received data from stream: %s" % [p_state.stream])
+	print("Data: %s" % [parse_json(p_state.state)])
 ```
 
 ## Receiving stream presence events
@@ -228,6 +229,7 @@ func _ready():
 	socket.connect("received_stream_presence", self, "_on_stream_presence")
 
 func _on_stream_presence(p_presence : NakamaRTAPI.StreamPresenceEvent):
+	print("Received presences on stream: %s" % [p_presence.stream])
 	for p in p_presence.joins:
 		print("User ID: %s, Username: %s, Status: %s" % [p.user_id, p.username, p.status])
 	for p in p_presence.leaves:

--- a/docs/advanced-streams.md
+++ b/docs/advanced-streams.md
@@ -105,7 +105,9 @@ SocketListener listener = new AbstractSocketListener() {
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_stream_state", self, "_on_stream_state")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_stream_state", self, "_on_stream_state")
 
 func _on_stream_state(p_state : NakamaRTAPI.StreamData):
 	print("Received data from stream: %s" % parse_json(p_state.state))
@@ -221,7 +223,9 @@ SocketListener listener = new AbstractSocketListener() {
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_stream_presence", self, "_on_stream_presence")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_stream_presence", self, "_on_stream_presence")
 
 func _on_stream_presence(p_presence : NakamaRTAPI.StreamPresenceEvent):
 	for p in p_presence.joins:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -63,6 +63,10 @@ let client : Client = Builder("defaultkey")
 let client : Client = Builder.defaults(serverKey: "defaultkey")
 ```
 
+```gdscript tab="Godot"
+var client := Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
+```
+
 Every user account is created from one of the [options used to authenticate](#authenticate). We call each of these options a "link" because it's a way to access the user's account. You can add more than one link to each account which is useful to enable users to login in multiple ways across different devices.
 
 ## Authenticate
@@ -215,6 +219,16 @@ client.login(with: message).then { session in
 }
 ```
 
+```gdscript tab="Godot"
+# Unique ID is not supported by Godot in HTML5, use a different way to generate an id, or a different authentication option.
+var deviceid = OS.get_unique_id()
+var session : NakamaSession = yield(client.authenticate_device_async(deviceid), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
+```
+
 ```tab="REST"
 POST /v2/account/authenticate/device?create=true&username=mycustomusername
 Host: 127.0.0.1:7350
@@ -329,6 +343,16 @@ client.register(with: message).then { session in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
 // Use client.login(...) after register.
+```
+
+```gdscript tab="Godot"
+var email = "email@example.com"
+var password = "3bc8f72e95a9"
+var session : NakamaSession = yield(client.authenticate_email_async(email, password, "mycustomusername", true), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
 ```
 
 ```tab="REST"
@@ -463,6 +487,15 @@ client.register(with: message).then { session in
 }
 ```
 
+```gdscript tab="Godot"
+var oauth_token = "..."
+var session : NakamaSession = yield(client.authenticate_facebook_async(oauth_token), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
+```
+
 ```tab="REST"
 POST /v2/account/authenticate/facebook?create=true&username=mycustomusername&import=true
 Host: 127.0.0.1:7350
@@ -570,6 +603,15 @@ client.register(with: message).then { session in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var oauth_token = "..."
+var session : NakamaSession = yield(client.authenticate_google_async(oauth_token), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
 ```
 
 ```tab="REST"
@@ -734,6 +776,20 @@ client.register(with: message).then { session in
 // Use client.login(...) after register.
 ```
 
+```gdscript tab="Godot"
+var bundle_id = "..."
+var player_id = "..."
+var public_key_url = "..."
+var salt = "..."
+var signature = "..."
+var timestamp = "..."
+var session : NakamaSession = yield(client.authenticate_game_center_async(bundle_id, player_id, public_key_url, salt, signature, timestamp), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
+```
+
 ```tab="REST"
 POST /v2/account/authenticate/gamecenter?create=true&username=mycustomusername
 Host: 127.0.0.1:7350
@@ -837,6 +893,15 @@ client.register(with: message).then { session in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
 // Use client.login(...) after register.
+```
+
+```gdscript tab="Godot"
+var steam_token = "..."
+var session : NakamaSession = yield(client.authenticate_steam_async(steam_token), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
 ```
 
 ```tab="REST"
@@ -943,6 +1008,15 @@ client.register(with: message).then { session in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
 // Use client.login(...) after register.
+```
+
+```gdscript tab="Godot"
+var custom_id = "some-custom-id"
+var session : NakamaSession = yield(client.authenticate_custom_async(custom_id), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Successfully authenticated: %s" % session)
 ```
 
 ```tab="REST"
@@ -1059,6 +1133,15 @@ client.login(with: message).then { session in
 }
 ```
 
+```gdscript tab="Godot"
+var session : NakamaSession = yield(client.authenticate_device_async(deviceid), "completed")
+if session.is_exception():
+	print("An error occured: %s" % session)
+	return
+print("Id '%s' Username '%s'" % [session.id, session.username])
+print("Session expired? %s" % session.expired)
+```
+
 ### Connect
 
 With a session you can connect with the server and exchange realtime messages. Most of our clients do not auto-reconnect for you so you should handle it with your own code.
@@ -1139,6 +1222,15 @@ client.connect(with: session).then { _ in
 });
 ```
 
+```gdscript tab="Godot"
+var socket := Nakama.create_socket_from(client)
+var connected : NakamaAsyncResult = yield(socket.connect_async(session), "completed")
+if connected.is_exception():
+	print("An error occured: %s" % connected)
+	return
+print("Socket connected.")
+```
+
 ### Expiry
 
 Sessions can expire and become invalid. If this happens you'll need to reauthenticate with the server and get a new session. You can adjust the session lifetime on the server with the cmdflag "--session.token_expiry_sec 604800". See the [Session configuration](#install-configuration.md#session) page.
@@ -1193,6 +1285,11 @@ if (session->isExpired())
 if (session.isExpired(new Date())) {
   System.out.println("Session has expired. Must reauthenticate!");
 }
+```
+
+```gdscript tab="Godot"
+if session.expired:
+	print("Session has expired. Must reauthenticate!")
 ```
 
 ## Link or unlink
@@ -1281,6 +1378,15 @@ client.send(with: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var custom_id = "some-custom-id"
+var linked : NakamaAsyncResult = yield(client.link_custom_async(session, custom_id), "completed")
+if linked.is_exception():
+	print("An error occured: %s" % linked)
+	return
+print("Id '%s' linked for user '%s'" % [custom_id, session.user_id])
 ```
 
 ```tab="REST"
@@ -1378,6 +1484,15 @@ client.send(with: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var custom_id = "some-custom-id"
+var unlinked : NakamaAsyncResult = yield(client.unlink_custom_async(session, custom_id), "completed")
+if unlinked.is_exception():
+	print("An error occured: %s" % unlinked)
+	return
+print("Id '%s' unlinked for user '%s'" % [custom_id, session.user_id])
 ```
 
 ```tab="REST"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -64,7 +64,7 @@ let client : Client = Builder.defaults(serverKey: "defaultkey")
 ```
 
 ```gdscript tab="Godot"
-var client := Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
+onready var client := Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
 ```
 
 Every user account is created from one of the [options used to authenticate](#authenticate). We call each of these options a "link" because it's a way to access the user's account. You can add more than one link to each account which is useful to enable users to login in multiple ways across different devices.
@@ -1223,12 +1223,15 @@ client.connect(with: session).then { _ in
 ```
 
 ```gdscript tab="Godot"
-var socket := Nakama.create_socket_from(client)
-var connected : NakamaAsyncResult = yield(socket.connect_async(session), "completed")
-if connected.is_exception():
-	print("An error occured: %s" % connected)
-	return
-print("Socket connected.")
+# Make this a node variable, or it will disconnect when the function that creates it returns.
+onready var socket := Nakama.create_socket_from(client)
+
+func _ready():
+	var connected : NakamaAsyncResult = yield(socket.connect_async(session), "completed")
+	if connected.is_exception():
+		print("An error occured: %s" % connected)
+		return
+	print("Socket connected.")
 ```
 
 ### Expiry

--- a/docs/gameplay-leaderboards.md
+++ b/docs/gameplay-leaderboards.md
@@ -140,6 +140,16 @@ client.send(message: message).then { records in
 }
 ```
 
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var score = 100
+var record : NakamaAPI.ApiLeaderboardRecord = yield(client.write_leaderboard_record_async(session, leaderboard_id, score), "completed")
+if record.is_exception():
+	print("An error occured: %s" % record)
+	return
+print("New record username %s and score %s" % [record.username, record.score])
+```
+
 ```tab="REST"
 POST /v2/leaderboard/<leaderboardId>
 Host: 127.0.0.1:7350
@@ -294,6 +304,16 @@ client.send(message: message).then { records in
 }
 ```
 
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var score = 100
+var record : NakamaAPI.ApiLeaderboardRecord = yield(client.write_leaderboard_record_async(session, leaderboard_id, score), "completed")
+if record.is_exception():
+	print("An error occured: %s" % record)
+	return
+print("New record username %s and score %s" % [record.username, record.score])
+```
+
 ```tab="REST"
 POST /v2/leaderboard/<leaderboardId>
 Host: 127.0.0.1:7350
@@ -418,6 +438,18 @@ client.send(message: message).then { records in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
 ```
+
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var result : NakamaAPI.ApiLeaderboardRecordList = yield(client.list_leaderboard_records_async(session, leaderboard_id), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for r in result.records:
+	var record : NakamaAPI.ApiLeaderboardRecord = r
+	print("Record username %s and score %s" % [record.username, record.score])
+```
+
 
 ```tab="REST"
 GET /v2/leaderboard/<leaderboardId>
@@ -633,6 +665,26 @@ client.send(message: message).then { records in
 }
 ```
 
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var result : NakamaAPI.ApiLeaderboardRecordList = yield(client.list_leaderboard_records_async(session, leaderboard_id, null, null, 100), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for r in result.records:
+	var record : NakamaAPI.ApiLeaderboardRecord = r
+	print("Record username %s and score %s" % [record.username, record.score])
+
+if result.next_cursor:
+	result = yield(client.list_leaderboard_records_async(session, leaderboard_id, null, null, 100, result.next_cursor), "completed")
+	if result.is_exception():
+		print("An error occured: %s" % result)
+		return
+	for r in result.records:
+		var record : NakamaAPI.ApiLeaderboardRecord = r
+		print("Record username %s and score %s" % [record.username, record.score])
+```
+
 ```tab="REST"
 GET /v2/leaderboard/<leaderboardId>?cursor=<next_cursor>
 Host: 127.0.0.1:7350
@@ -763,6 +815,18 @@ client.send(message: message).then { records in
 }
 ```
 
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var owner_ids = ["some", "friend", "user id"]
+var result : NakamaAPI.ApiLeaderboardRecordList = yield(client.list_leaderboard_records_async(session, leaderboard_id, owner_ids), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for r in result.records:
+	var record : NakamaAPI.ApiLeaderboardRecord = r
+	print("Record username %s and score %s" % [record.username, record.score])
+```
+
 ```tab="REST"
 GET /v2/leaderboard/<leaderboardId>?owner_ids=some&owner_ids=friends
 Host: 127.0.0.1:7350
@@ -842,6 +906,18 @@ LeaderboardRecordList records = client.listLeaderboardRecordsAroundOwner(session
 
 ```swift tab="Swift"
 // Will be made available soon.
+```
+
+```gdscript tab="Godot"
+var leaderboard_id = "level1"
+var owner_id = "user id"
+var result : NakamaAPI.ApiLeaderboardRecordList = yield(client.list_leaderboard_records_around_owner_async(session, leaderboard_id, owner_id), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for r in result.records:
+	var record : NakamaAPI.ApiLeaderboardRecord = r
+	print("Record username %s and score %s" % [record.username, record.score])
 ```
 
 ```tab="REST"

--- a/docs/gameplay-matchmaker.md
+++ b/docs/gameplay-matchmaker.md
@@ -153,6 +153,22 @@ MatchmakerTicket matchmakerTicket = socket.addMatchmaker(
     query, minCount, maxCount, stringProperties, numericProperties).get();
 ```
 
+```gdscript tab="Godot"
+var query = "*"
+var min_count = 2
+var max_count = 4
+var string_properties = { "region": "europe" }
+var numeric_properties = { "rank": 8 }
+var matchmaker_ticket : NakamaRTAPI.MatchmakerTicket = yield(
+	socket.add_matchmaker_async(query, min_count, max_count, string_properties, numeric_properties),
+	"completed"
+)
+if matchmaker_ticket.is_exception():
+	print("An error occured: %s" % matchmaker_ticket)
+	return
+print("Got ticket: %s" % [matchmaker_ticket])
+```
+
 ### Query
 
 The query defines how the user wants to find their opponents. Queries inspect the properties set by matchmaker users to find users eligible to be matched, or can ignore them to find any available users using the wildcard `*` query. A typical matchmaker query may look for opponents between given ranks, or in a particular region.
@@ -298,6 +314,20 @@ MatchmakerTicket matchmakerTicket = socket.addMatchmaker(
     query, minCount, maxCount, stringProperties, numericProperties).get();
 ```
 
+```gdscript tab="Godot"
+var query = "+properties.region:europe +properties.rank:>=5 +properties.rank:<=10"
+var string_properties = { "region": "europe"}
+var numeric_properties = { "rank": 8 }
+var matchmaker_ticket : NakamaRTAPI.MatchmakerTicket = yield(
+	socket.add_matchmaker_async(query, 2, 4, string_properties, numeric_properties),
+	"completed"
+)
+if matchmaker_ticket.is_exception():
+	print("An error occured: %s" % matchmaker_ticket)
+	return
+print("Got ticket: %s" % [matchmaker_ticket])
+```
+
 Or use the wildcard query `"*"` to ignore opponents properties and match with anyone:
 
 ```js tab="JavaScript"
@@ -427,6 +457,22 @@ MatchmakerTicket matchmakerTicket = socket.addMatchmaker(
     query, minCount, maxCount, stringProperties, numericProperties).get();
 ```
 
+```gdscript tab="Godot"
+var query = "*"
+var min_count = 2
+var max_count = 4
+var string_properties = { "region": "europe" }
+var numeric_properties = { "rank": 8 }
+var matchmaker_ticket : NakamaRTAPI.MatchmakerTicket = yield(
+	socket.add_matchmaker_async(query, min_count, max_count, string_properties, numeric_properties),
+	"completed"
+)
+if matchmaker_ticket.is_exception():
+	print("An error occured: %s" % matchmaker_ticket)
+	return
+print("Got ticket: %s" % [matchmaker_ticket])
+```
+
 ### Minimum and maximum count
 
 Users wishing to matchmake must specify a minimum and maximum number of opponents the matchmaker must find to succeed. If there aren't enough users that match the query to satisfy the minimum count, the user remains in the pool.
@@ -551,6 +597,20 @@ int maxCount = 4;
 MatchmakerTicket matchmakerTicket = socket.addMatchmaker(query, minCount, maxCount).get();
 ```
 
+```gdscript tab="Godot"
+var query = "*"
+var min_count = 4
+var max_count = 4
+var matchmaker_ticket : NakamaRTAPI.MatchmakerTicket = yield(
+	socket.add_matchmaker_async(query, min_count, max_count),
+	"completed"
+)
+if matchmaker_ticket.is_exception():
+	print("An error occured: %s" % matchmaker_ticket)
+	return
+print("Got ticket: %s" % [matchmaker_ticket])
+```
+
 ## Matchmaker tickets
 
 Each time a user is added to the matchmaker pool they receive a ticket, a unique identifier for their entry into the pool.
@@ -639,6 +699,20 @@ int maxCount = 4;
 MatchmakerTicket matchmakerTicket = socket.addMatchmaker(query, minCount, maxCount).get();
 ```
 
+```gdscript tab="Godot"
+var query = "*"
+var min_count = 2
+var max_count = 4
+var matchmaker_ticket : NakamaRTAPI.MatchmakerTicket = yield(
+	socket.add_matchmaker_async(query, min_count, max_count),
+	"completed"
+)
+if matchmaker_ticket.is_exception():
+	print("An error occured: %s" % matchmaker_ticket)
+	return
+print("Got ticket: %s" % [matchmaker_ticket])
+```
+
 This ticket is used when the server notifies the client on matching success. It distinguishes between multiple possible matchmaker operations for the same user. The user may also cancel the matchmaking process using the ticket at any time, but only before the ticket has been fulfilled.
 
 ## Remove a user from the matchmaker
@@ -694,6 +768,14 @@ rtClient->removeMatchmaker(ticket, []()
 ```java tab="Java"
 // "matchmakerTicket" is returned by the matchmaker.
 socket.removeMatchmaker(matchmakerTicket.getTicket()).get();
+```
+
+```gdscript tab="Godot"
+var removed : NakamaAsyncResult = yield(socket.remove_matchmaker_async(matchmaker_ticket.ticket), "completed")
+if removed.is_exception():
+	print("An error occured: %s" % removed)
+	return
+print("Removed from matchmaking %s" % [matchmaker_ticket.ticket])
 ```
 
 If the user has multiple entries in the matchmaker only the one identified by the ticket will be removed.
@@ -758,6 +840,14 @@ SocketListener listener = new AbstractSocketListener() {
     System.out.format("Matched opponents: %s", opponents.toString());
   }
 };
+```
+
+```gdscript tab="Godot"
+socket.connect("received_matchmaker_matched", self, "_on_matchmaker_matched")
+
+func _on_matchmaker_matched(p_matched : NakamaRTAPI.MatchmakerMatched):
+	print("Received MatchmakerMatched message: %s" % [p_matched])
+	print("Matched opponents: %s" % [p_matched.users])
 ```
 
 ## Join a match
@@ -842,4 +932,14 @@ SocketListener listener = new AbstractSocketListener() {
     socket.joinMatchToken(matched.getToken()).get();
   }
 };
+```
+
+```gdscript tab="Godot"
+func _on_matchmaker_matched(p_matched : NakamaRTAPI.MatchmakerMatched):
+	print("Received MatchmakerMatched message: %s" % [p_matched])
+	var joined_match : NakamaRTAPI.Match = yield(socket.join_matched_async(p_matched), "completed")
+	if joined_match.is_exception():
+		print("An error occured: %s" % joined_match)
+		return
+	print("Joined match: %s" % [joined_match])
 ```

--- a/docs/gameplay-matchmaker.md
+++ b/docs/gameplay-matchmaker.md
@@ -843,7 +843,9 @@ SocketListener listener = new AbstractSocketListener() {
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_matchmaker_matched", self, "_on_matchmaker_matched")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_matchmaker_matched", self, "_on_matchmaker_matched")
 
 func _on_matchmaker_matched(p_matched : NakamaRTAPI.MatchmakerMatched):
 	print("Received MatchmakerMatched message: %s" % [p_matched])

--- a/docs/gameplay-multiplayer-realtime.md
+++ b/docs/gameplay-multiplayer-realtime.md
@@ -54,6 +54,14 @@ Match match = socket.createMatch().get();
 System.out.format("Created match with ID %s.", match.getId());
 ```
 
+```gdscript tab="Godot"
+var created_match : NakamaRTAPI.Match = yield(socket.create_match_async(), "completed")
+if created_match.is_exception():
+	print("An error occured: %s" % created_match)
+	return
+print("New match with id %s.", created_match.match_id)
+```
+
 A user can [leave a match](#leave-a-match) at any point which will notify all other users.
 
 ## Join a match
@@ -152,6 +160,16 @@ Match match = socket.joinMatch(matchId).get();
 for (UserPresence presence : match.getPresences()) {
   System.out.format("User id %s name %s.", presence.getUserId(), presence.getUsername());
 }
+```
+
+```gdscript tab="Godot"
+var match_id = "<matchid>"
+var joined_match = yield(socket.join_match_async(match_id), "completed")
+if joined_match.is_exception():
+	print("An error occured: %s" % joined_match)
+	return
+for presence in joined_match.presences:
+	print("User id %s name %s'." % [presence.user_id, presence.username])
 ```
 
 The list of match opponents returned in the success callback might not include all users. It contains users who are connected to the match so far.
@@ -272,6 +290,19 @@ public void onMatchPresence(final MatchPresenceEvent matchPresence) {
 });
 ```
 
+```gdscript tab="Godot"
+var connected_opponents = {}
+
+socket.connect("received_match_presence", self, "_on_match_presence")
+
+func _on_match_presence(p_presence : NakamaRTAPI.MatchPresenceEvent):
+	for p in p_presence.joins:
+		connected_opponents[p.user_id] = p
+	for p in p_presence.leaves:
+		connected_opponents.erase(p.user_id)
+	print("Connected opponents: %s" % [connected_opponents])
+```
+
 No server updates are sent if there are no changes to the presence list.
 
 ## Send data messages
@@ -331,6 +362,13 @@ String id = "<matchid>";
 int opCode = 1;
 String data = "{\"message\":\"Hello world\"}";
 socket.sendMatchData(id, opCode, data);
+```
+
+```gdscript tab="Godot"
+var match_id = "<matchid>"
+var op_code = 1
+var new_state = {"hello": "world"}
+socket.send_match_state_async(match_id, op_code, JSON.print(new_state))
 ```
 
 ## Receive data messages
@@ -441,6 +479,13 @@ SocketListener listener = new AbstractSocketListener() {
 };
 ```
 
+```gdscript tab="Godot"
+socket.connect("received_match_state", self, "_on_match_state")
+
+func _on_match_state(p_state : NakamaRTAPI.MatchData):
+	print("Received match state with opcode %s, data %s" % [p_state.op_code, parse_json(p_state.data)])
+```
+
 ## Leave a match
 
 Users can leave a match at any point. A match ends when all users have left.
@@ -478,6 +523,15 @@ rtClient->leaveMatch(matchId);
 ```java tab="Java"
 String matchId = "<matchid>";
 socket.leaveMatch(matchId).get();
+```
+
+```gdscript tab="Godot"
+var match_id = "<matchid>"
+var leave : NakamaAsyncResult = yield(socket.leave_match_async(match_id), "completed")
+if leave.is_exception():
+	print("An error occured: %s" % leave)
+	return
+print("Match left")
 ```
 
 !!! Note

--- a/docs/gameplay-multiplayer-realtime.md
+++ b/docs/gameplay-multiplayer-realtime.md
@@ -293,7 +293,9 @@ public void onMatchPresence(final MatchPresenceEvent matchPresence) {
 ```gdscript tab="Godot"
 var connected_opponents = {}
 
-socket.connect("received_match_presence", self, "_on_match_presence")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_match_presence", self, "_on_match_presence")
 
 func _on_match_presence(p_presence : NakamaRTAPI.MatchPresenceEvent):
 	for p in p_presence.joins:
@@ -480,7 +482,9 @@ SocketListener listener = new AbstractSocketListener() {
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_match_state", self, "_on_match_state")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_match_state", self, "_on_match_state")
 
 func _on_match_state(p_state : NakamaRTAPI.MatchData):
 	print("Received match state with opcode %s, data %s" % [p_state.op_code, parse_json(p_state.data)])

--- a/docs/gameplay-tournaments.md
+++ b/docs/gameplay-tournaments.md
@@ -138,6 +138,20 @@ TournamentList tournaments = client.listTournaments(session, categoryStart, cate
 // Will be made available soon.
 ```
 
+```gdscript tab="Godot"
+var category_start = 1
+var category_end = 2
+var start_time = 1538147711
+var end_time = -1 # all tournaments from the start time
+var limit = 100 # number to list per page
+var cursor = null
+var result : NakamaAPI.ApiTournamentList = yield(client.list_tournaments_async(session, category_start, category_end, start_time, end_time, limit, cursor), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Tournaments: %s" % [result])
+```
+
 ```tab="REST"
 GET /v2/tournament
   ?category_start=<category_start>
@@ -214,6 +228,15 @@ client.joinTournament(session, id).get();
 
 ```swift tab="Swift"
 // Will be made available soon.
+```
+
+```gdscript tab="Godot"
+var id = "someid"
+var success : NakamaAsyncResult = yield(client.join_tournament_async(session, id), "completed")
+if success.is_exception():
+	print("An error occured: %s" % success)
+	return
+print("Joined tournament")
 ```
 
 ```tab="REST"
@@ -303,6 +326,17 @@ LeaderboardRecordList records = client.listLeaderboardRecords(session, id, sessi
 
 ```swift tab="Swift"
 // Will be made available soon.
+```
+
+```gdscript tab="Godot"
+var id = "someid"
+var limit = 100
+var cursor = null
+var result : NakamaAPI.ApiTournamentRecordList = yield(client.list_tournament_records_async(session, id, [session.user_id], limit, cursor), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Records: %s" % [result])
 ```
 
 ```tab="REST"
@@ -397,6 +431,17 @@ TournamentRecordList records = client.listTournamentRecordsAroundOwner(session, 
 
 ```swift tab="Swift"
 // Will be made available soon.
+```
+
+```gdscript tab="Godot"
+var id = "someid"
+var owner_id = "some user ID"
+var limit = 100
+var result : NakamaAPI.ApiTournamentRecordList = yield(client.list_tournament_records_around_owner_async(session, id, owner_id, limit), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Records: %s" % [result])
 ```
 
 ```tab="REST"
@@ -508,6 +553,21 @@ LeaderboardRecord record = client.writeTournamentRecord(session, id, score, subs
 
 ```swift tab="Swift"
 // Will be made available soon.
+```
+
+```gdscript tab="Godot"
+var id = "someid"
+var score = 100
+var subscore = 10
+var metadata = JSON.print({
+	"weather_conditions": "sunny",
+	"track_name": "Silverstone"
+})
+var new_record : NakamaAPI.ApiLeaderboardRecord = yield(client.write_tournament_record_async(session, id, score, subscore, metadata), "completed")
+if new_record.is_exception():
+	print("An error occured: %s" % new_record)
+	return
+print("Record: %s" % [new_record])
 ```
 
 ```tab="REST"

--- a/docs/godot-client-guide.md
+++ b/docs/godot-client-guide.md
@@ -35,12 +35,13 @@ To authenticate you should follow our recommended pattern in your client code:
 &nbsp;&nbsp; 1\. Build an instance of the client.
 
 ```gdscript
-	var client = Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
+onready var client = Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
 ```
 
 &nbsp;&nbsp; 2\. Authenticate a user. By default the server will create a user if it doesn't exist.
 
 ```gdscript
+func _ready():
 	var email = "hello@example.com"
 	var password = "somesupersecretpassword"
 	# Use yield(client.function(), "completed") to wait for the request to complete. Hopefully, Godot will implement the await keyword in future versions.
@@ -105,7 +106,12 @@ Since Godot Engine does not support exceptions, whenever you make an async reque
 The client can create one or more sockets with the server. Each socket can have it's own event listeners registered for responses received from the server.
 
 ```gdscript
-	var socket = Nakama.create_socket_from(client)
+onready var client := Nakama.create_client("defaultkey", "127.0.0.1", 7350, "http")
+onready var socket := Nakama.create_socket_from(client)
+
+func _ready():
+	# Authenticate with the client and receive the session as shown above.
+	# ...
 	socket.connect("connected", self, "_on_socket_connected")
 	socket.connect("closed", self, "_on_socket_closed")
 	socket.connect("received_error", self, "_on_socket_error")

--- a/docs/runtime-code-basics.md
+++ b/docs/runtime-code-basics.md
@@ -745,6 +745,16 @@ client.send(message: message).then { result in
 }
 ```
 
+```gdscript tab="Godot"
+var payload = {"PokemonName": "dragonite"}
+var rpc_id = "get_pokemon"
+var pokemon_info : NakamaAPI.ApiRpc = yield(client.rpc_async(session, rpc_id, JSON.print(payload)), "completed")
+if pokemon_info.is_exception():
+	print("An error occured: %s" % pokemon_info)
+	return
+print("Retrieved pokemon info: %s" % [parse_json(pokemon_info.payload)])
+```
+
 ```tab="REST"
 POST /v2/rpc/get_pokemon
 Host: 127.0.0.1:7350

--- a/docs/social-friends.md
+++ b/docs/social-friends.md
@@ -75,6 +75,15 @@ client.send(message: message).catch { err in
 }
 ```
 
+```gdscript tab="Godot"
+var ids = ["user-id1", "user-id2"]
+var usernames = ["username1"]
+var result : NakamaAsyncResult = yield(client.add_friends_async(session, ids, usernames), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+```
+
 ```tab="REST"
 POST /v2/friend?ids=user-id1&ids=user-id2&usernames=username1
 Host: 127.0.0.1:7350
@@ -163,6 +172,16 @@ client.send(message: message).then { friends in
 }
 ```
 
+```gdscript tab="Godot"
+var list : NakamaAPI.ApiFriendList = yield(client.list_friends_async(session), "completed")
+if list.is_exception():
+	print("An error occured: %s" % list)
+	return
+for f in list.friends:
+	var friend = f as NakamaAPI.ApiFriend
+	print("User %s, status %s" % [friend.user.id, friend.state])
+```
+
 ```tab="REST"
 GET /v2/friend
 Host: 127.0.0.1:7350
@@ -237,6 +256,16 @@ client.send(message: message).then { _ in
 }
 ```
 
+```gdscript tab="Godot"
+var ids = ["user-id1", "user-id2"]
+var usernames = ["username1"]
+var remove : NakamaAsyncResult = yield(client.delete_friends_async(session, ids, usernames), "completed")
+if remove.is_exception():
+	print("An error occured: %s" % remove)
+	return
+print("Remove friends: user ids %s, usernames %s" % [ids, usernames])
+```
+
 ```tab="REST"
 DELETE /v2/friend?ids=user-id1&ids=user-id2&usernames=username1
 Host: 127.0.0.1:7350
@@ -308,6 +337,16 @@ client.send(message: message).then { _ in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var ids = ["user-id1", "user-id2"]
+var usernames = ["username1"]
+var block : NakamaAsyncResult = yield(client.block_friends_async(session, ids, usernames), "completed")
+if block.is_exception():
+	print("An error occured: %s" % block)
+	return
+print("Remove friends: user ids %s, usernames %s" % [ids, usernames])
 ```
 
 ```tab="REST"

--- a/docs/social-groups-clans.md
+++ b/docs/social-groups-clans.md
@@ -116,6 +116,16 @@ client.send(message: message).then { groups in
 }
 ```
 
+```gdscript tab="Godot"
+var list : NakamaAPI.ApiGroupList = yield(client.list_groups_async(session, "heroes*", 20), "completed")
+if list.is_exception():
+	print("An error occured: %s" % list)
+	return
+for g in list.groups:
+	var group = g as NakamaAPI.ApiGroup
+	print("Group: name %s, id %s", [group.name, group.id])
+```
+
 ```tab="REST"
 GET /v2/group?limit=20&name=heroes%&cursor=<cursor>
 Host: 127.0.0.1:7350
@@ -261,6 +271,27 @@ client.send(message: message).then { groups in
 }
 ```
 
+```gdscript tab="Godot"
+var list : NakamaAPI.ApiGroupList = yield(client.list_groups_async(session, "heroes*", 20), "completed")
+if list.is_exception():
+	print("An error occured: %s" % list)
+	return
+for g in list.groups:
+	var group = g as NakamaAPI.ApiGroup
+	print("Group: name %s, id %s", [group.name, group.id])
+
+var cursor = list.cursor
+while cursor: # While there are more results get next page.
+	list = yield(client.list_groups_async(session, "heroes*", 20, cursor), "completed")
+	if list.is_exception():
+		print("An error occured: %s" % list)
+		return
+	for g in list.groups:
+		var group = g as NakamaAPI.ApiGroup
+		print("Group: name %s, id %s", [group.name, group.id])
+	cursor = list.cursor
+```
+
 ```tab="REST"
 GET /v2/group?limit=20&name=heroes%&cursor=somecursor
 Host: 127.0.0.1:7350
@@ -348,6 +379,15 @@ client.send(message: message).then { _ in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var join : NakamaAsyncResult = yield(client.join_group_async(session, group_id), "completed")
+if join.is_exception():
+	print("An error occured: %s" % join)
+	return
+print("Sent group join request %s" % group_id)
 ```
 
 ```tab="REST"
@@ -462,6 +502,17 @@ client.send(message: message).then { groups in
 }
 ```
 
+```gdscript tab="Godot"
+var user_id = "<user id>"
+var result : NakamaAPI.ApiUserGroupList = yield(client.list_user_groups_async(session, user_id), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for ug in result.user_groups:
+	var g = ug.group as NakamaAPI.ApiGroup
+	print("Group %s role %s", g.id, ug.state)
+```
+
 ```tab="REST"
 GET /v2/user/<user id>/group
 Host: 127.0.0.1:7350
@@ -557,6 +608,17 @@ client.send(message: message).then { users in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var member_list : NakamaAPI.ApiGroupUserList = yield(client.list_group_users_async(session, group_id), "completed")
+if member_list.is_exception():
+	print("An error occured: %s" % member_list)
+	return
+for ug in member_list.group_users:
+	var u = ug.user as NakamaAPI.ApiUser
+	print("User %s role %s" % [u.id, ug.state])
 ```
 
 ```tab="REST"
@@ -685,6 +747,16 @@ client.send(message: message).then { groups in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var group_name = "pizza-lovers"
+var group_desc = "pizza lovers, pineapple haters"
+var group : NakamaAPI.ApiGroup = yield(client.create_group_async(session, group_name, group_desc), "completed")
+if group.is_exception():
+	print("An error occured: %s" % group)
+	return
+print("New group: %s" % group)
 ```
 
 ```tab="REST"
@@ -848,6 +920,16 @@ client.send(message: message).then { _ in
 }
 ```
 
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var description = "Better than Marvel Heroes!"
+var update : NakamaAsyncResult = yield(client.update_group_async(session, group_id, null, description), "completed")
+if update.is_exception():
+	print("An error occured: %s" % update)
+	return
+print("Updated group")
+```
+
 ```tab="REST"
 PUT /v2/group/<group id>
 Host: 127.0.0.1:7350
@@ -923,6 +1005,15 @@ client.send(message: message).then { _ in
       NSLog("Error %@ : %@", err, nkErr.message)
   }
 }
+```
+
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var leave : NakamaAsyncResult = yield(client.leave_group_async(session, group_id), "completed")
+if leave.is_exception():
+	print("An error occured: %s" % leave)
+	return
+print("Group left")
 ```
 
 ```tab="REST"
@@ -1020,6 +1111,16 @@ client.send(message: message).then { _ in
 }
 ```
 
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var user_ids = ["<user id>"]
+var accept : NakamaAsyncResult = yield(client.add_group_users_async(session, group_id, user_ids), "completed")
+if accept.is_exception():
+	print("An error occured: %s" % accept)
+	return
+print("User added")
+```
+
 ```tab="REST"
 POST /v2/group/<group id>/add
 Host: 127.0.0.1:7350
@@ -1112,6 +1213,16 @@ client.send(message: message).then { _ in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var user_ids = ["<user id>"]
+var promote : NakamaAsyncResult = yield(client.promote_group_users_async(session, group_id, user_ids), "completed")
+if promote.is_exception():
+	print("An error occured: %s" % promote)
+	return
+print("User promoted")
 ```
 
 ```tab="REST"
@@ -1208,6 +1319,16 @@ client.send(message: message).then { _ in
 }
 ```
 
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var user_ids = ["<user id>"]
+var kick : NakamaAsyncResult = yield(client.kick_group_users_async(session, group_id, user_ids), "completed")
+if kick.is_exception():
+	print("An error occured: %s" % kick)
+	return
+print("User kicked")
+```
+
 ```tab="REST"
 POST /v2/group/<group id>/kick
 Host: 127.0.0.1:7350
@@ -1287,6 +1408,15 @@ client.send(message: message).then { _ in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var remove : NakamaAsyncResult = yield(client.delete_group_async(session, group_id), "completed")
+if remove.is_exception():
+	print("An error occured: %s" % remove)
+	return
+print("Group removed")
 ```
 
 ```tab="REST"

--- a/docs/social-in-app-notifications.md
+++ b/docs/social-in-app-notifications.md
@@ -121,6 +121,14 @@ client.onNotification = { notification in
 }
 ```
 
+```gdscript tab="Godot"
+socket.connect("received_notification", self, "_on_notification")
+
+func _on_notification(p_notification : NakamaAPI.ApiNotification):
+	print(p_notification)
+	print(p_notification.content)
+```
+
 ## List notifications
 
 You can list notifications which were received when the user was offline. These notifications are ones which were marked "persistent" when sent. The exact logic depends on your game or app but we suggest you retrieve notifications after a client reconnects. You can then display a UI within your game or app with the list.
@@ -208,6 +216,15 @@ client.send(message: message).then { notifications in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var result : NakamaAPI.ApiNotificationList = yield(client.list_notifications_async(session, 10), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for n in result.notifications:
+	print("Subject '%s' content '%s'" % [n.subject, n.content])
 ```
 
 ```tab="REST"
@@ -365,6 +382,23 @@ client.send(message: message).then { notifications in
 }
 ```
 
+```gdscript tab="Godot"
+var result : NakamaAPI.ApiNotificationList = yield(client.list_notifications_async(session, 1), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for n in result.notifications:
+	print("Subject '%s' content '%s'" % [n.subject, n.content])
+while result.cacheable_cursor and result.notifications:
+	result = yield(client.list_notifications_async(session, 10, result.cacheable_cursor), "completed")
+	if result.is_exception():
+		print("An error occured: %s" % result)
+		return
+	for n in result.notifications:
+		print("Subject '%s' content '%s'" % [n.subject, n.content])
+print("Done")
+```
+
 ```tab="REST"
 GET /v2/notification?limit=100&cursor=<cacheableCursor>
 Host: 127.0.0.1:7350
@@ -467,6 +501,16 @@ client.send(message: message).then { notifications in
 }
 ```
 
+```gdscript tab="Godot"
+var cursor = "<cacheable-cursor>";
+var result : NakamaAPI.ApiNotificationList = yield(client.list_notifications_async(session, 10, cursor), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for n in result.notifications:
+	print("Subject '%s' content '%s'" % [n.subject, n.content])
+```
+
 ```tab="REST"
 GET /v2/notification?limit=10&cursor=<cacheableCursor>
 Host: 127.0.0.1:7350
@@ -526,6 +570,15 @@ client.send(message: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var notification_ids = ["<notification-id>"]
+var delete : NakamaAsyncResult = yield(client.delete_notifications_async(session, notification_ids), "completed")
+if delete.is_exception():
+	print("An error occured: %s" % delete)
+	return
+print("Deleted")
 ```
 
 ```tab="REST"

--- a/docs/social-in-app-notifications.md
+++ b/docs/social-in-app-notifications.md
@@ -122,7 +122,9 @@ client.onNotification = { notification in
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_notification", self, "_on_notification")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_notification", self, "_on_notification")
 
 func _on_notification(p_notification : NakamaAPI.ApiNotification):
 	print(p_notification)

--- a/docs/social-realtime-chat.md
+++ b/docs/social-realtime-chat.md
@@ -98,7 +98,9 @@ client.onTopicMessage = { message in
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_channel_message", self, "_on_channel_message")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_channel_message", self, "_on_channel_message")
 
 func  _on_channel_message(p_message : NakamaAPI.ApiChannelMessage):
 	print(p_message)
@@ -802,7 +804,7 @@ client.send(message: message).then { topics in
 var room_users = {}
 
 func _ready():
-	# Listener for new chat room presences.
+	# First, setup the socket as explained in the authentication section.
 	socket.connect("received_channel_presence", self, "_on_channel_presence")
 
 	# Connect to the room.

--- a/docs/social-realtime-chat.md
+++ b/docs/social-realtime-chat.md
@@ -97,6 +97,15 @@ client.onTopicMessage = { message in
 }
 ```
 
+```gdscript tab="Godot"
+socket.connect("received_channel_message", self, "_on_channel_message")
+
+func  _on_channel_message(p_message : NakamaAPI.ApiChannelMessage):
+	print(p_message)
+	print("Received a message on channel: %s" % [p_message.channel_id])
+	print("Message content: %s" % [p_message.content])
+```
+
 In group chat a user will receive other messages from the server. These messages contain events on users who join or leave the group, when someone is promoted as an admin, etc. You may want users to see these messages in the chat stream or ignore them in the UI.
 
 You can identify event messages from chat messages by the message "Type".
@@ -156,6 +165,11 @@ switch messageType {
   default:
     NSLog("Received message with event type %d", messageType.rawValue)
 }
+```
+
+```gdscript tab="Godot"
+if p_message.code != 0:
+	print("Received message with code:", p_message.code)
 ```
 
 | Code | Purpose | Source | Description |
@@ -277,6 +291,18 @@ client.send(message: message).then { topics in
 }
 ```
 
+```gdscript tab="Godot"
+var roomname = "MarvelMovieFans"
+var persistence = true
+var hidden = false
+var type = NakamaSocket.ChannelType.Room
+var channel : NakamaRTAPI.Channel = yield(socket.join_chat_async(roomname, type, persistence, hidden), "completed")
+if channel.is_exception():
+	print("An error occured: %s" % channel)
+	return
+print("Now connected to channel id: '%s'" % [channel.id])
+```
+
 The `roomId` variable contains an ID used to [send messages](#send-messages).
 
 ### groups
@@ -385,6 +411,18 @@ client.send(message: message).then { topics in
 }
 ```
 
+```gdscript tab="Godot"
+var group_id = "<group id>"
+var persistence = true
+var hidden = false
+var type = NakamaSocket.ChannelType.Group
+var channel : NakamaRTAPI.Channel = yield(socket.join_chat_async(group_id, type, persistence, hidden), "completed")
+if channel.is_exception():
+	print("An error occured: %s" % channel)
+	return
+print("Now connected to channel id: '%s'" % [channel.id])
+```
+
 The `"<group id>"` variable must be an ID used to [send messages](#send-messages).
 
 ### direct
@@ -491,6 +529,18 @@ client.send(message: message).then { topics in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var user_id = "<user id>"
+var persistence = true
+var hidden = false
+var type = NakamaSocket.ChannelType.DirectMessage
+var channel : NakamaRTAPI.Channel = yield(socket.join_chat_async(user_id, type, persistence, hidden), "completed")
+if channel.is_exception():
+	print("An error occured: %s" % channel)
+	return
+print("Now connected to channel id: '%s'" % [channel.id])
 ```
 
 The `"<user id>"` variable must be an ID used to [send messages](#send-messages).
@@ -748,6 +798,36 @@ client.send(message: message).then { topics in
 }
 ```
 
+```gdscript tab="Godot"
+var room_users = {}
+
+func _ready():
+	# Listener for new chat room presences.
+	socket.connect("received_channel_presence", self, "_on_channel_presence")
+
+	# Connect to the room.
+	var roomname = "MarvelMovieFans"
+	var persistence = true
+	var hidden = false
+	var type = NakamaSocket.ChannelType.Room
+	var channel : NakamaRTAPI.Channel = yield(socket.join_chat_async(roomname, type, persistence, hidden), "completed")
+	if channel.is_exception():
+		print("An error occured: %s" % channel)
+		return
+
+	# Add users already present in chat room.
+	for p in channel.presences:
+		room_users[p.user_id] = p
+	print("Users in room: %s" % [room_users.keys()])
+
+func _on_channel_presence(p_presence : NakamaRTAPI.ChannelPresenceEvent):
+	for p in p_presence.joins:
+		room_users[p.user_id] = p
+	for p in p_presence.leaves:
+		room_users.erase(p.user_id)
+	print("Users in room: %s" % [room_users.keys()])
+```
+
 !!! Tip
     The server is optimized to only push presence updates when other users join or leave the chat.
 
@@ -835,6 +915,16 @@ client.send(message: message).then { ack in
 }
 ```
 
+```gdscript tab="Godot"
+var channel_id = "<channel id>"
+var data = { "some": "data" }
+var message_ack : NakamaRTAPI.ChannelMessageAck = yield(socket.write_chat_message_async(channel_id, data), "completed")
+if message_ack.is_exception():
+	print("An error occured: %s" % message_ack)
+	return
+print("Sent message %s" % [message_ack])
+```
+
 ## Leave chat
 
 A user can leave a chat channel to no longer be sent messages in realtime. This can be useful to "mute" a chat while in some other part of the UI.
@@ -889,6 +979,15 @@ client.send(message: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var channel_id = "<channel id>"
+var result : NakamaAsyncResult = yield(socket.leave_chat_async(channel_id), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Left chat")
 ```
 
 ## Message history
@@ -1007,6 +1106,18 @@ client.send(message: message).then { messages in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var channel_id = "<channel id>"
+var result : NakamaAPI.ApiChannelMessageList = yield(client.list_channel_messages_async(session, channel_id, 10), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for m in result.messages:
+	var message : NakamaAPI.ApiChannelMessage = m as NakamaAPI.ApiChannelMessage
+	print("Message has id %s and content %s" % [message.message_id, message.content])
+print("Get the next page of messages with the cursor: %s" % [result.next_cursor])
 ```
 
 ```tab="REST"
@@ -1189,6 +1300,26 @@ client.send(message: message).then { messages in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var channel_id = "<channel id>"
+var forward = true
+var result : NakamaAPI.ApiChannelMessageList = yield(client.list_channel_messages_async(session, channel_id, 10, forward), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for m in result.messages:
+	var message : NakamaAPI.ApiChannelMessage = m as NakamaAPI.ApiChannelMessage
+	print("Message has id %s and content %s" % [message.message_id, message.content])
+if result.next_cursor:
+	result = yield(client.list_channel_messages_async(session, channel_id, 10, forward, result.next_cursor), "completed")
+	if result.is_exception():
+		print("An error occured: %s" % result)
+		return
+	for m in result.messages:
+		var message : NakamaAPI.ApiChannelMessage = m as NakamaAPI.ApiChannelMessage
+		print("Message has id %s and content %s" % [message.message_id, message.content])
 ```
 
 ```tab="REST"

--- a/docs/social-status.md
+++ b/docs/social-status.md
@@ -38,6 +38,14 @@ rtClient->updateStatus("Hello everyone!");
 socket.updateStatus("Hello everyone!").get();
 ```
 
+```gdscript tab="Godot"
+var update : NakamaAsyncResult = yield(socket.update_status_async(JSON.print({"status": "happy"})), "completed")
+if update.is_exception():
+	print("An error occured: %s" % update)
+	return
+print("Status updated")
+```
+
 The status can be set and updated as often as needed with this operation.
 
 !!! Tip
@@ -73,6 +81,14 @@ rtClient->updateStatus("");
 
 ```java tab="Java"
 socket.updateStatus(null).get();
+```
+
+```gdscript tab="Godot"
+var leave : NakamaAsyncResult = yield(socket.update_status_async(""), "completed")
+if leave.is_exception():
+	print("An error occured: %s" % leave)
+	return
+print("Status updated")
 ```
 
 ## Receive status updates
@@ -176,6 +192,17 @@ SocketListener listener = new AbstractSocketListener() {
 };
 ```
 
+```gdscript tab="Godot"
+socket.connect("received_status_presence", self, "_on_status_presence")
+
+func _on_status_presence(p_presence : NakamaRTAPI.StatusPresenceEvent):
+	print(p_presence)
+	for j in p_presence.joins:
+		print("%s joined with status: %s" % [j.user_id, j.status])
+	for j in p_presence.leaves:
+		print("%s left with status: %s" % [j.user_id, j.status])
+```
+
 If a user is disconnecs or appears offline they will leave their previous status but there will be no corresponding new status.
 
 ## Follow users
@@ -239,6 +266,15 @@ rtClient->followUsers({ "<user id>" }, successCallback);
 socket.followUsers("<user id>").get();
 ```
 
+```gdscript tab="Godot"
+var user_ids = ["<user-id1>", "<user-id2>"]
+var status : NakamaRTAPI.Status = yield(socket.follow_users_async(user_ids), "completed")
+if status.is_exception():
+	print("An error occured: %s" % status)
+	return
+print(status)
+```
+
 !!! Note
     Following a user is only active with the current session. When the user disconnects they automatically unfollow anyone they may have followed while connected.
 
@@ -272,4 +308,13 @@ rtClient->unfollowUsers({ "<user id>" });
 
 ```java tab="Java"
 socket.unfollowUsers("<user id>").get();
+```
+
+```gdscript tab="Godot"
+var user_ids = ["<user-id1>", "<user-id2>"]
+var status : NakamaAsyncResult = yield(socket.unfollow_users_async(user_ids), "completed")
+if status.is_exception():
+	print("An error occured: %s" % status)
+	return
+print(status)
 ```

--- a/docs/social-status.md
+++ b/docs/social-status.md
@@ -193,7 +193,9 @@ SocketListener listener = new AbstractSocketListener() {
 ```
 
 ```gdscript tab="Godot"
-socket.connect("received_status_presence", self, "_on_status_presence")
+func _ready():
+	# First, setup the socket as explained in the authentication section.
+	socket.connect("received_status_presence", self, "_on_status_presence")
 
 func _on_status_presence(p_presence : NakamaRTAPI.StatusPresenceEvent):
 	print(p_presence)

--- a/docs/storage-access-controls.md
+++ b/docs/storage-access-controls.md
@@ -121,6 +121,18 @@ client.send(message: message).then { list in
 }
 ```
 
+```gdscript tab="Godot"
+var result : NakamaAPI.ApiStorageObjects = yield(client.read_storage_objects_async(session, [
+	NakamaStorageObjectId.new("configuration", "config")
+]), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Read objects:")
+for o in result.objects:
+	print("%s" % o)
+```
+
 ```tab="REST"
 POST /v2/storage
 Host: 127.0.0.1:7350
@@ -326,6 +338,19 @@ client.send(message: message).then { list in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var army_setup = "{ \"soldiers\": 50 }";
+# "2" refers to Public Read permission
+# "1" refers to Owner Write permission
+var acks : NakamaAPI.ApiStorageObjectAcks = yield(client.write_storage_objects_async(session, [
+	NakamaWriteStorageObject.new("saves", "savegame", 2, 1, army_setup, "")
+]), "completed")
+if acks.is_exception():
+	print("An error occured: %s" % acks)
+	return
+print("Stored objects: %s" % [acks.acks])
 ```
 
 ```tab="REST"

--- a/docs/storage-collections.md
+++ b/docs/storage-collections.md
@@ -181,6 +181,24 @@ client.send(message: message).then { list in
 }
 ```
 
+```gdscript tab="Godot"
+var save_game = "{ \"progress\": 50 }"
+var my_stats = "{ \"skill\": 24 }"
+var can_read = 1
+var can_write = 1
+var version = ""
+var acks : NakamaAPI.ApiStorageObjectAcks = yield(client.write_storage_objects_async(session, [
+	NakamaWriteStorageObject.new("saves", "savegame", can_read, can_write, save_game, version),
+	NakamaWriteStorageObject.new("stats", "skills", can_read, can_write, my_stats, version)
+]), "completed")
+if acks.is_exception():
+	print("An error occured: %s" % acks)
+	return
+print("Successfully stored objects:")
+for a in acks.acks:
+	print("%s" % a)
+```
+
 ```tab="REST"
 PUT /v2/storage
 Host: 127.0.0.1:7350
@@ -332,6 +350,22 @@ client.send(message: message).then { list in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var save_game = "{ \"progress\": 50 }"
+var can_read = 1
+var can_write = 1
+var version = "<version>"
+var acks : NakamaAPI.ApiStorageObjectAcks = yield(client.write_storage_objects_async(session, [
+	NakamaWriteStorageObject.new("saves", "savegame", can_read, can_write, save_game, version)
+]), "completed")
+if acks.is_exception():
+	print("An error occured: %s" % acks)
+	return
+print("Successfully stored objects:")
+for a in acks.acks:
+	print("%s" % a)
 ```
 
 ```tab="REST"
@@ -505,6 +539,22 @@ client.send(message: message).then { list in
 }
 ```
 
+```gdscript tab="Godot"
+var save_game = "{ \"progress\": 50 }"
+var can_read = 1
+var can_write = 1
+var version = "*" # represents "no version".
+var acks : NakamaAPI.ApiStorageObjectAcks = yield(client.write_storage_objects_async(session, [
+	NakamaWriteStorageObject.new("saves", "savegame", can_read, can_write, save_game, version)
+]), "completed")
+if acks.is_exception():
+	print("An error occured: %s" % acks)
+	return
+print("Successfully stored objects:")
+for a in acks.acks:
+	print("%s" % a)
+```
+
 ```tab="REST"
 PUT /v2/storage
 Host: 127.0.0.1:7350
@@ -649,6 +699,18 @@ client.send(message: message).then { list in
 }
 ```
 
+```gdscript tab="Godot"
+var result : NakamaAPI.ApiStorageObjects = yield(client.read_storage_objects_async(session, [
+	NakamaStorageObjectId.new("saves", "savegame", session.user_id)
+]), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+print("Read objects:")
+for o in result.objects:
+	print("%s" % o)
+```
+
 ```tab="REST"
 POST /v2/storage
 Host: 127.0.0.1:7350
@@ -758,6 +820,15 @@ client.send(message: message).then { list in
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var limit = 100 # default is 10.
+var objects : NakamaAPI.ApiStorageObjectList = yield(client.list_storage_objects_async(session, "saves", session.user_id, limit), "completed")
+if objects.is_exception():
+	print("An error occured: %s" % objects)
+	return
+print("List objects: %s" % objects)
 ```
 
 ```tab="REST"
@@ -870,6 +941,16 @@ client.send(message: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var del : NakamaAsyncResult = yield(client.delete_storage_objects_async(session, [
+	NakamaStorageObjectId.new("saves", "savegame")
+]), "completed")
+if del.is_exception():
+	print("An error occured: %s" % del)
+	return
+print("Deleted objects.")
 ```
 
 ```tab="REST"
@@ -1002,6 +1083,16 @@ client.send(message: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var del = yield(client.delete_storage_objects_async(session, [
+	NakamaStorageObjectId.new("saves", "savegame", session.user_id, "<version>")
+]), "completed")
+if del.is_exception():
+	print("An error occured: %s" % del)
+	return
+print("Deleted objects.")
 ```
 
 ```tab="REST"

--- a/docs/user-accounts.md
+++ b/docs/user-accounts.md
@@ -78,6 +78,16 @@ client.send(message: message).then { selfuser in
 }
 ```
 
+```gdscript tab="Godot"
+var account : NakamaAPI.ApiAccount = yield(client.get_account_async(session), "completed")
+if account.is_exception():
+	print("An error occured: %s" % account)
+	return
+var user = account.user
+print("User id '%s' and username '%s'." % [user.id, user.username])
+print("User's wallet: %s." % account.wallet)
+```
+
 ```tab="REST"
 GET /v2/account
 Host: 127.0.0.1:7350
@@ -264,6 +274,18 @@ client.send(message: message).then { users in
 }
 ```
 
+```gdscript tab="Godot"
+var ids = ["userid1", "userid2"]
+var usernames = ["username1", "username2"]
+var facebook_ids = ["facebookid1"]
+var result : NakamaAPI.ApiUsers = yield(client.get_users_async(session, ids, usernames, facebook_ids), "completed")
+if result.is_exception():
+	print("An error occured: %s" % result)
+	return
+for u in result.users:
+	print("User id '%s' username '%s'" % [u.id, u.username])
+```
+
 ```tab="REST"
 GET /v2/user?ids=userid1&ids=userid2&usernames=username1&usernames=username2&facebook_ids=facebookid1
 Host: 127.0.0.1:7350
@@ -384,6 +406,17 @@ client.send(message: message).then {
 }.catch { err in
   NSLog("Error %@ : %@", err, (err as! NakamaError).message)
 }
+```
+
+```gdscript tab="Godot"
+var display_name = "My new name";
+var avatar_url = "http://graph.facebook.com/avatar_url";
+var location = "San Francisco";
+var update : NakamaAsyncResult = yield(client.update_account_async(session, null, display_name, avatar_url, null, location), "completed")
+if update.is_exception():
+	print("An error occured: %s" % update)
+	return
+print("Account updated")
 ```
 
 ```tab="REST"


### PR DESCRIPTION
Would have been nice if GDscript was supported by `mkdocs`. Github does, there is probably a file for that. Need to investigate.

Note:
Godot does not allow code outside functions (only variable definitions), and sockets need to be created as node variables (or they will disconnect when they go out if scope, this is pretty common behaviour, I hope it's clear enough in this examples, I also updated the client guide).


**Note 2: Some inconsistencies/bugs I found when testing the snippets with Nakama 2.11.0**

- `list_notifications_async` always returns a cursor, even when the notification list is empty.
   This means we can't check if the cursor is null, but have to check if the list is empty to know when we fetched all the notifications.

- The `tournament` endpoint (`http://127.0.0.1:7350/v2/tournament?category_start=1&category_end=2&start_time=1538147711&end_time=-1&limit=100`) does not accept `end_time=-1`, complaining about `"bad DoubleValue: -1"` which is a valid double so probably something about parsing :thinking: .

- [`StreamData`](https://github.com/heroiclabs/nakama-common/blob/master/rtapi/realtime.proto#L441) no longer contains a subject, so other examples seems incorrect
