### PR TITLE
Fix typo in an "An example module" of Go "Runtime Code Basics" docs.

### DIFF
--- a/docs/runtime-code-basics.md
+++ b/docs/runtime-code-basics.md
@@ -625,7 +625,7 @@ func LookupPokemon(logger runtime.Logger, name string) (map[string]interface{}, 
   body, err := ioutil.ReadAll(resp.Body)
   if err != nil {
     logger.Error("Failed to read body %v", err.Error())
-    return nil, error
+    return nil, err
   }
   if resp.StatusCode >= 400 {
     logger.Error("Failed request %v %v", resp.StatusCode, body)


### PR DESCRIPTION
Hi, thank you for your work on the project. 😍
It's helped me a lot while I'm building something with it.

There has an error "type error is not an expression" when building Go code in a provided example.
Only changing "error" to "err" will fix the issue.

## Reference
- https://heroiclabs.com/docs/runtime-code-basics/#an-example-module
