### PR TITLE
document 'port' argument as a string when passed to js client

### DIFF
--- a/docs/cocos2d-x-js-client-guide.md
+++ b/docs/cocos2d-x-js-client-guide.md
@@ -30,7 +30,7 @@ The client object is used to execute all logic against the server:
 ```js
 var serverkey = "defaultkey";
 var host = "127.0.0.1";
-var port = 7350;
+var port = "7350";
 var useSSL = false;
 var timeout = 7000; // ms
 
@@ -38,7 +38,7 @@ var client = new nakamajs.Client(serverkey, host, port, useSSL, timeout);
 ```
 
 !!! Note
-    By default the client uses connection settings "127.0.0.1" and 7350 port to connect to a local Nakama server.
+    By default the client uses connection settings "127.0.0.1" and "7350" port to connect to a local Nakama server.
 
 ```js
 var client = new nakamajs.Client();

--- a/docs/javascript-client-guide.md
+++ b/docs/javascript-client-guide.md
@@ -28,12 +28,12 @@ When you've [downloaded](#download) the "nakama-js.umd.js" file you should impor
 The client object is used to execute all logic against the server. In your main JavaScript function you'll need to create a client object:
 
 ```js
-var client = new nakamajs.Client("defaultkey", "127.0.0.1", 7350);
+var client = new nakamajs.Client("defaultkey", "127.0.0.1", "7350");
 client.ssl = false;
 ```
 
 !!! Note
-    By default the client uses connection settings "127.0.0.1" and 7350 to connect to a local Nakama server.
+    By default the client uses connection settings "127.0.0.1" and "7350" to connect to a local Nakama server.
 
 ```js
 var client = new nakamajs.Client("defaultkey");


### PR DESCRIPTION
I noticed when using the Javascript SDK that the `Client` constructor accepts `port` as a string, not a number.

I assume the cocos2d-x-js client also uses the same code, so I updated that documentation as well.