### PR TITLE
Upgrade to mkdocs 1.1.2 and mkdocs-material 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,7 @@ pip install mkdocs --upgrade
 pip install mkdocs-material --upgrade
 ```
 
-*Note:* For Python 3.7, you may need to run the following instead
-```shell
-pip3 install pip --upgrade
-pip3 install mkdocs --upgrade
-pip3 install mkdocs-material --upgrade
-```
+*Note:* For Python 3.7, you may need to run the above commands using `pip3` instead of `pip`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project uses Markdown for documentation which is compiled with [mkdocs](htt
 
 ```shell
 pip install pip --upgrade
-pip install -I mkdocs==1.0.4
-pip install -I mkdocs-material==4.6.3
+pip install -I mkdocs==1.1.2
+pip install -I mkdocs-material==5.3.0
 ```
 
 *Note:* For Python 3.7, you may need to run the above commands using `pip3` instead of `pip`.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project uses Markdown for documentation which is compiled with [mkdocs](htt
 
 ```shell
 pip install pip --upgrade
-pip install -I mkdocs==1.1.2
-pip install -I mkdocs-material==5.3.0
+pip install mkdocs==1.1.2
+pip install mkdocs-material==5.3.0
 ```
 
 *Note:* For Python 3.7, you may need to run the above commands using `pip3` instead of `pip`.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project uses Markdown for documentation which is compiled with [mkdocs](htt
 
 ```shell
 pip install pip --upgrade
-pip install mkdocs --upgrade
-pip install mkdocs-material --upgrade
+pip install -I mkdocs==1.0.4
+pip install -I mkdocs-material==4.6.3
 ```
 
 *Note:* For Python 3.7, you may need to run the above commands using `pip3` instead of `pip`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ repo_name: 'heroiclabs/nakama'
 repo_url: 'https://github.com/heroiclabs/nakama'
 
 # Copyright
-copyright: 'Copyright &copy; 2019 Heroic Labs'
+copyright: 'Copyright &copy; 2020 Heroic Labs'
 
 # Documentation and theme
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,18 +36,21 @@ extra_css:
   - 'css/extra.css'
 
 # Options
+plugins:
+  - search:
+      lang:
+        - en
+
 extra:
-  search:
-    language: 'en'
   social:
-  - type: 'globe'
-    link: 'https://heroiclabs.com'
-  - type: 'github'
-    link: 'https://github.com/heroiclabs'
-  - type: 'twitter'
-    link: 'https://twitter.com/heroicdev'
-  - type: 'linkedin'
-    link: 'https://www.linkedin.com/company/heroic-labs'
+    - icon: 'fontawesome/solid/globe'
+      link: 'https://heroiclabs.com'
+    - icon: 'fontawesome/brands/github'
+      link: 'https://github.com/heroiclabs'
+    - icon: 'fontawesome/brands/twitter'
+      link: 'https://twitter.com/heroicdev'
+    - icon: 'fontawesome/brands/linkedin'
+      link: 'https://www.linkedin.com/company/heroic-labs'
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
Closes #146 

In our 4.x version, I saw buggy-looking radio buttons locally as our code tabs. I assume we override the .css for those in a private Heroic Labs website repo.

In 5.x, the code tabs look locally as they do in the publicly hosted site, which leads me to believe some bugs were fixed with their theming.

Upgrade guide listed here: https://squidfunk.github.io/mkdocs-material/releases/5/

Once I'm onboarded in the next week or two I can test on Google Cloud.