### PR TITLE
Fix documentation of default http runtime key to match go code

### DIFF
--- a/docs/install-configuration.md
+++ b/docs/install-configuration.md
@@ -33,7 +33,7 @@ There are a few configuration properties that need to be changed in most environ
 | `runtime.path` | Path of modules to scan and load. Defaults to `data_dir/modules`.
 | `database.address` | List of database nodes to connect to. It should follow the form of `username:password@address:port/dbname` (`postgres://` protocol is appended to the path automatically). Defaults to `root@localhost:26257`.
 | `socket.server_key` | Server key to use to establish a connection to the server. Default value is `defaultkey`.
-| `runtime.http_key` | Key is used to protect the server's runtime HTTP invocations. Default value is `defaultkey`.
+| `runtime.http_key` | Key is used to protect the server's runtime HTTP invocations. Default value is `defaulthttpkey`.
 | `session.encryption_key` | The encryption key used to produce the client token. Default value is `defaultencryptionkey`.
 | `session.token_expiry_sec` | Session token expiry in seconds. Default value is 60.
 
@@ -342,7 +342,7 @@ runtime:
     - "example_apikey=example_apivalue"
     - "encryptionkey=afefa==e332*u13=971mldq"
   path: "/tmp/modules/folders"
-  http_key: "defaultkey"
+  http_key: "defaulthttpkey"
 
 socket:
   server_key: "defaultkey"

--- a/docs/runtime-code-basics.md
+++ b/docs/runtime-code-basics.md
@@ -390,7 +390,7 @@ This function can be called with any HTTP client. For example, with cURL you cou
     RPC functions can be called both from clients and through server to server calls. You can tell them apart by [checking if the context has a user ID](#register-hooks) - server to server calls will never have a user ID. If you want to scope functions to never be accessible from the client just return an error if you find a user ID in the context.
 
 ```shell
-curl "http://127.0.0.1:7350/v2/rpc/http_handler_path?http_key=defaultkey" \
+curl "http://127.0.0.1:7350/v2/rpc/http_handler_path?http_key=defaulthttpkey" \
      -d '"{\"some\": \"data\"}"' \
      -H 'Content-Type: application/json' \
      -H 'Accept: application/json'


### PR DESCRIPTION
Was getting an error in one of the `nakama-js` tests due to a mismatched default HTTP runtime key. If/when we accept this I can update the JS SDK and any other erroneous SDK test suites.

See what nakama actually uses as a default here: https://github.com/heroiclabs/nakama/blob/master/server/config.go#L651