### PR TITLE
Update Nakama image version in example docker-compose

### DIFF
--- a/docs/install-docker-quickstart.md
+++ b/docs/install-docker-quickstart.md
@@ -98,7 +98,7 @@ services:
       - "8080:8080"
   nakama:
     container_name: nakama
-    image: heroiclabs/nakama:2.11.1
+    image: heroiclabs/nakama:2.12.0
     entrypoint:
       - "/bin/sh"
       - "-ecx"


### PR DESCRIPTION
I thought this was causing version conflicts, but it seems not. Would it be best to increment the version in the docs, or remove the version entirely maybe?