### PR TITLE
put space in "join a match" .NET tab

### DIFF
--- a/docs/gameplay-multiplayer-realtime.md
+++ b/docs/gameplay-multiplayer-realtime.md
@@ -92,7 +92,7 @@ A user can join a specific match by ID. Matches can be joined at any point until
     });
     ```
 
-===".NET"
+=== ".NET"
     ```csharp
     var matchId = "<matchid>";
     var match = await socket.JoinMatchAsync(matchId);


### PR DESCRIPTION
problem:
> ![image](https://user-images.githubusercontent.com/27877342/98724455-bd3c1a80-23ce-11eb-9124-11b74f7f6344.png)
