### PR TITLE
Fix the Lua example for distributing tournament rewards.

### DIFF
--- a/docs/gameplay-tournaments.md
+++ b/docs/gameplay-tournaments.md
@@ -791,7 +791,7 @@ A simple reward distribution function which sends a persistent notification to t
 	  local notifications = {}
 	  local wallet_updates = {}
 	  local records, owner_records, nc, pc = nk.leaderboard_records_list(tournament.id, nil, 10, nil, expiry)
-	  for i = 0, #records do
+	  for i = 1, #records do
 	    notifications[i] = {
 	      code = 1,
 	      content = { coins = 100 },


### PR DESCRIPTION
Lua table indices start at 1.  This fixes the error, "attempt to index a non-table object(nil)".