### PR TITLE
Improved consistency of language in Client Guides' Handle Events section

### DIFF
--- a/docs/android-java-client-guide.md
+++ b/docs/android-java-client-guide.md
@@ -199,14 +199,14 @@ Event handlers only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| onDisconnect | Handles an event for when the client is disconnected from the server. |
+| onDisconnect | Received when the client is disconnected from the server. |
 | onNotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onChannelMessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onChannelPresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onChannelPresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onMatchState | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onMatchPresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onMatchPresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onMatchmakerMatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onStatusPresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onStatusPresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onStreamPresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onStreamState | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/cocos2d-x-client-guide.md
+++ b/docs/cocos2d-x-client-guide.md
@@ -309,14 +309,14 @@ Event handlers only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| onDisconnect | Handles an event for when the client is disconnected from the server. |
+| onDisconnect | Received when the client is disconnected from the server. |
 | onNotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onChannelMessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onChannelPresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onChannelPresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onMatchState | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onMatchPresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onMatchPresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onMatchmakerMatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onStatusPresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onStatusPresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onStreamPresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onStreamState | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/cocos2d-x-js-client-guide.md
+++ b/docs/cocos2d-x-js-client-guide.md
@@ -203,15 +203,15 @@ Some events only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| ondisconnect | Handles an event for when the client is disconnected from the server. |
+| ondisconnect | Received when the client is disconnected from the server. |
 | onerror | Receives events about server errors. |
 | onnotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onchannelmessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onchannelpresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onchannelpresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onmatchdata | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onmatchpresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onmatchpresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onmatchmakermatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onstatuspresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onstatuspresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onstreampresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onstreamdata | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/cpp-client-guide.md
+++ b/docs/cpp-client-guide.md
@@ -316,14 +316,14 @@ Event handlers only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| onDisconnect | Handles an event for when the client is disconnected from the server. |
+| onDisconnect | Received when the client is disconnected from the server. |
 | onNotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onChannelMessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onChannelPresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onChannelPresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onMatchState | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onMatchPresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onMatchPresence | Received join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onMatchmakerMatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onStatusPresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onStatusPresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onStreamPresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onStreamState | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/defold-client-guide.md
+++ b/docs/defold-client-guide.md
@@ -153,15 +153,15 @@ Event handlers only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| on_disconnect | Handles an event for when the client is disconnected from the server. |
+| on_disconnect | Received when the client is disconnected from the server. |
 | on_error | Receives events about server errors. |
 | on_notification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | on_channelmessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| on_channelpresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| on_channelpresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | on_matchdata | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| on_matchpresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| on_matchpresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | on_matchmakermatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| on_statuspresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| on_statuspresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | on_streampresence | Receives [stream](advanced-streams.md) join and leave event. |
 | on_streamdata | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/godot-client-guide.md
+++ b/docs/godot-client-guide.md
@@ -167,16 +167,16 @@ Signal handlers only need to be implemented for the features you want to use.
 
 | Signals | Description |
 | --------- | ----------- |
-| connected | Receive an event when the socket connects. |
-| closed | Handles an event for when the client is disconnected from the server. |
-| received\_error | Receives events about server errors. |
+| connected | Received when the socket connects. |
+| closed | Received when the client is disconnected from the server. |
+| received\_error | Received when there is a server error. |
 | received\_notification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | received\_channel\_message | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| received\_channel\_presence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| received\_channel\_presence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | received\_match\_state | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| received\_match\_presence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| received\_match\_presence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | received\_matchmaker\_matched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| received\_status\_presence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| received\_status\_presence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | received\_stream\_presence | Receives [stream](advanced-streams.md) join and leave event. |
 | received\_stream\_state | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/javascript-client-guide.md
+++ b/docs/javascript-client-guide.md
@@ -179,15 +179,15 @@ Some events only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| ondisconnect | Handles an event for when the client is disconnected from the server. |
+| ondisconnect | Received when the client is disconnected from the server. |
 | onerror | Receives events about server errors. |
 | onnotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onchannelmessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onchannelpresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onchannelpresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onmatchdata | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onmatchpresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onmatchpresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onmatchmakermatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onstatuspresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onstatuspresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onstreampresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onstreamdata | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/swift-ios-client-guide.md
+++ b/docs/swift-ios-client-guide.md
@@ -167,14 +167,14 @@ Some events only need to be implemented for the features you want to use.
 
 | Callbacks | Description |
 | --------- | ----------- |
-| a | Handles an event for when the client is disconnected from the server. |
+| a | Received when the client is disconnected from the server. |
 | b | Receives events about server errors. |
-| c | Handles [realtime match](gameplay-multiplayer-realtime.md) messages. |
+| c | Receives [realtime match](gameplay-multiplayer-realtime.md) messages. |
 | d | Receives events when the [matchmaker](gameplay-matchmaker.md) has found match participants. |
-| e | When in a [realtime match](gameplay-multiplayer-realtime.md) receives events for when users join or leave. |
+| e | Receives join or leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md) |
 | f | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | g | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| h | Similar to "OnMatchPresence" it handles join and leave events but within [chat](social-realtime-chat.md). |
+| h | Receives join and leave events within [chat](social-realtime-chat.md). |
 -->
 
 ## Promise chains

--- a/docs/unity-client-guide.md
+++ b/docs/unity-client-guide.md
@@ -160,15 +160,15 @@ Event handlers only need to be implemented for the features you want to use.
 | Callbacks | Description |
 | --------- | ----------- |
 | Connected | Receive an event when the socket connects. |
-| Closed | Handles an event for when the client is disconnected from the server. |
+| Closed | Receives an event for when the client is disconnected from the server. |
 | ReceivedError | Receives events about server errors. |
 | ReceivedNotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | ReceivedChannelMessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| ReceivedChannelPresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| ReceivedChannelPresence | Received join and leave events within [chat](social-realtime-chat.md). |
 | ReceivedMatchState | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| ReceivedMatchPresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| ReceivedMatchPresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | ReceivedMatchmakerMatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| ReceivedStatusPresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| ReceivedStatusPresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | ReceivedStreamPresence | Receives [stream](advanced-streams.md) join and leave event. |
 | ReceivedStreamState | Receives [stream](advanced-streams.md) data sent by the server. |
 

--- a/docs/unreal-client-guide.md
+++ b/docs/unreal-client-guide.md
@@ -256,11 +256,11 @@ Event handlers only need to be implemented for the features you want to use.
 | onDisconnect | Handles an event for when the client is disconnected from the server. |
 | onNotification | Receives live [in-app notifications](social-in-app-notifications.md) sent from the server. |
 | onChannelMessage | Receives [realtime chat](social-realtime-chat.md) messages sent by other users. |
-| onChannelPresence | It handles join and leave events within [chat](social-realtime-chat.md). |
+| onChannelPresence | Receives join and leave events within [chat](social-realtime-chat.md). |
 | onMatchState | Receives [realtime multiplayer](gameplay-multiplayer-realtime.md) match data. |
-| onMatchPresence | It handles join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
+| onMatchPresence | Receives join and leave events within [realtime multiplayer](gameplay-multiplayer-realtime.md). |
 | onMatchmakerMatched | Received when the [matchmaker](gameplay-matchmaker.md) has found a suitable match. |
-| onStatusPresence | It handles status updates when subscribed to a user [status feed](social-status.md). |
+| onStatusPresence | Receives status updates when subscribed to a user [status feed](social-status.md). |
 | onStreamPresence | Receives [stream](advanced-streams.md) join and leave event. |
 | onStreamState | Receives [stream](advanced-streams.md) data sent by the server. |
 


### PR DESCRIPTION
Improved the consistency of the descriptions for the events in the Handle Events section of the Client Guides.

eg)
"It handles join and leave events within chat."
is now:
"Receives join and leave events within chat."

Which more closely resembles the other descriptions. This improves readability.