### PR TITLE
Fix joinMatch JS invocation from matchmaker docs

### DIFF
--- a/docs/gameplay-matchmaker.md
+++ b/docs/gameplay-matchmaker.md
@@ -915,7 +915,8 @@ The match token is also used to prevent unwanted users from attempting to join a
     ```js
     socket.onmatchmakermatched = (matched) => {
       console.info("Received MatchmakerMatched message: ", matched);
-      socket.joinMatch(matched.token);
+      const matchId = null;
+      socket.joinMatch(matchId, matched.token);
     };
     ```
 


### PR DESCRIPTION
At least `joinMatch(token)` gave me some "incorrect match id" errors.

In my minified JS nakama-js version first joinMatch argument is match_id and the second one is token_id.

`joinMatch(null, token)` worked for my case, so I guess the problem is just in docs? 