### PR TITLE
Fixed incorrect example in Create Party

### DIFF
--- a/docs/nakama/concepts/parties.md
+++ b/docs/nakama/concepts/parties.md
@@ -37,7 +37,7 @@ A party can be created by any user. You can limit the max number of users allowe
 
     // Create a closed party (i.e. approval needed to join) with 5 max users
     // This maximum does not include the party leader
-    var party = await socket.CreatePartyAsync(open: true, maxSize: 5);
+    var party = await socket.CreatePartyAsync(open: false, maxSize: 5);
     Debug.Log("New Party: " + party.ToString());
     ```
 


### PR DESCRIPTION
The example is to create an closed party but the `open` field was set to `true`, changed it to `false` instead