### PR TITLE
fix lua server authoritative example

### DIFF
--- a/docs/nakama/concepts/server-authoritative-multiplayer.md
+++ b/docs/nakama/concepts/server-authoritative-multiplayer.md
@@ -1002,7 +1002,7 @@ This is an example of a Ping-Pong match handler. Messages received by the server
         return nil
     end
 
-    local function match_signal(context, dispatcher, tick, state, data)
+    function M.match_signal(context, dispatcher, tick, state, data)
         return state, "signal received: " .. data
     end
 

--- a/docs/nakama/server-framework/function-reference.md
+++ b/docs/nakama/server-framework/function-reference.md
@@ -1227,7 +1227,7 @@ This module contains all the core gameplay APIs, all registration functions used
     local open = true
     local limit = 100
 
-    local groups = nk.group_list(group_name, lang_tag, members, open, limit)
+    local groups = nk.groups_list(group_name, lang_tag, open, members, limit)
     for i, group in ipairs(groups) do
     nk.logger_info(string.format("ID: %q - can enter? %q", group.id, group.can_enter))
     end


### PR DESCRIPTION
Minor issue, you will get an exception match_signal not found, unless you put into onto the module. Seems like other places was updated and just missed this one