### PR TITLE
fix typescript config example

### DIFF
--- a/docs/nakama/server-framework/typescript-setup.md
+++ b/docs/nakama/server-framework/typescript-setup.md
@@ -326,7 +326,7 @@ There are also changes to the `tsconfig.json` file that must be made. Using Roll
       "esModuleInterop": true,
       "noUnusedLocals": true,
       "removeComments": true,
-      "target": "es6",
+      "target": "es5",
       "module": "ESNext",
       "strict": false,
     },


### PR DESCRIPTION
The JavaScript runtime is powered by the goja VM which currently supports the JavaScript ES5 spec not ES6.